### PR TITLE
Fix Gradle trying to pull in depedencies that are already shadowed in the plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ version = (constantsSource =~ /\s+version\s*=\s*"(.*)";/)[0][1]
 
 configurations {
     shadowMe
-    implementation.extendsFrom shadowMe
+    compileOnly.extendsFrom shadowMe
 }
 
 repositories {

--- a/src/main/java/io/github/pacifistmc/forgix/Forgix.java
+++ b/src/main/java/io/github/pacifistmc/forgix/Forgix.java
@@ -34,7 +34,7 @@ public class Forgix {
     public static final String manifestVersionKey = "Forgix-Version";
 
     public static class Merge {
-        private final String version = "1.2.8";
+        private final String version = "1.2.9";
         public static Set<PosixFilePermission> perms;
 
         static {


### PR DESCRIPTION
Fixes issue 27.

Tested locally and the plugin is now published correctly and still works