### PR TITLE
Forgix should ignore files in data, config, and assets folders

### DIFF
--- a/src/main/java/io/github/pacifistmc/forgix/utils/FileUtils.java
+++ b/src/main/java/io/github/pacifistmc/forgix/utils/FileUtils.java
@@ -117,17 +117,19 @@ public class FileUtils {
         List<File> mixins = new ArrayList<>();
 
         for (File file : files) {
-            if (FilenameUtils.getExtension(file.getName()).equals("json")) {
-                String text = org.apache.commons.io.FileUtils.readFileToString(file, Charset.defaultCharset());
-                if (refmaps) {
-                    if (text.contains("\"mappings\":") || text.contains("\"data\":")) {
-                        mixins.add(file);
-                        continue;
+            if (!(file.getPath().contains("/data/") || file.getPath().contains("/assets/") || file.getPath().contains("/config/"))) {
+                if (FilenameUtils.getExtension(file.getName()).equals("json")) {
+                    String text = org.apache.commons.io.FileUtils.readFileToString(file, Charset.defaultCharset());
+                    if (refmaps) {
+                        if (text.contains("\"mappings\":") || text.contains("\"data\":")) {
+                            mixins.add(file);
+                            continue;
+                        }
                     }
-                }
 
-                if (text.contains("\"package\":")) {
-                    mixins.add(file);
+                    if (text.contains("\"package\":")) {
+                        mixins.add(file);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This aims to fix #30 and #33 by having Forgix ignore files in `data`, `assets`, and `config` directories. Open to feedback of course, but some resolution is necessary as without a fix like this one mods that provide worldgen files like Infinite Dimensions are unusable with Forgix, as it detects the `data` key as if it was a mixin.