### PR TITLE
Added the ability to set the base name, version, classifier and build destination for multi-version configuration and improved support for Kotlin DSL

### DIFF
--- a/src/main/java/io/github/pacifistmc/forgix/plugin/tasks/MergeVersionsTask.java
+++ b/src/main/java/io/github/pacifistmc/forgix/plugin/tasks/MergeVersionsTask.java
@@ -27,10 +27,10 @@ public abstract class MergeVersionsTask extends Jar {
             archiveBaseName.set(multiversion.archiveBaseName);
             archiveClassifier.set(multiversion.archiveClassifier);
             archiveVersion.set(multiversion.archiveVersion);
-            destinationDirectory.set(multiversion.destinationDirectory.get());
+            destinationDirectory.set(multiversion.getDestinationDirectory());
 
             // Set up input files
-            inputJarFiles.setFrom(multiversion.inputJars.get());
+            inputJarFiles.setFrom(multiversion.getInputJars());
         }
     }
 

--- a/src/main/java/io/github/pacifistmc/forgix/plugin/tasks/MergeVersionsTask.java
+++ b/src/main/java/io/github/pacifistmc/forgix/plugin/tasks/MergeVersionsTask.java
@@ -20,14 +20,18 @@ public abstract class MergeVersionsTask extends Jar {
 
     @Inject
     public MergeVersionsTask() {
-        // Configure archive properties
-        archiveBaseName.set(settings.archiveBaseName);
-        archiveClassifier.set(settings.archiveClassifier);
-        archiveVersion.set(project.provider(() -> "${settings.archiveVersion.get()}-multi"));
-        destinationDirectory.set(settings.destinationDirectory.get().dir("multiversion"));
+        var multiversion = settings.multiversionConfiguration;
 
-        // Set up input files
-        if (settings.multiversionConfiguration != null) inputJarFiles.setFrom(settings.multiversionConfiguration.inputJars);
+        if (multiversion != null) {
+            // Configure archive properties
+            archiveBaseName.set(multiversion.archiveBaseName);
+            archiveClassifier.set(multiversion.archiveClassifier);
+            archiveVersion.set(multiversion.archiveVersion);
+            destinationDirectory.set(multiversion.destinationDirectory.get());
+
+            // Set up input files
+            inputJarFiles.setFrom(multiversion.inputJars.get());
+        }
     }
 
     void mergeVersions() {
@@ -38,9 +42,9 @@ public abstract class MergeVersionsTask extends Jar {
         // Validate input
         if (inputJarFiles.getFiles().size() < 2) {
             throw new IllegalStateException("""
-                    At least 2 jars must be selected in order for multiversion.
-                    Please configure the forgix extension in your build.gradle file to specify the jars for multiversion.
-                    See https://github.com/PacifistMC/Forgix for more information.""");
+					At least 2 jars must be selected in order for multiversion.
+					Please configure the forgix extension in your build.gradle file to specify the jars for multiversion.
+					See https://github.com/PacifistMC/Forgix for more information.""");
         }
 
         // Perform the merge operation


### PR DESCRIPTION
I was writing a new template for future projects, and for testing purposes decided to try Forgix. I tried to get multi-version to work knowing it was experimental, and after a long time of troubleshooting, i found out why it didn't work. It seems you cant set the `inputJars` variable in Kotlin DSL because it interprets the variable as read only. To fix this i changed the variable type from `FileCollection` to `Property<FileCollection>` which allows Kotlin DSL to modify the variable.

I also found it annoying that the multi-version jar used the Forgix config's base name, version, classifier and build destination, so i decided to also add the ability to change those independent of the Forgix config.
I did this because when i build and merge, the jar names will contain both the mod version and the minecraft version, which i dont want the multi-version jar to have, it should only contain the mod version.
I also decided to add the ability to change the base name, classifier and build destination while i was at it.

I don't have much experience with making Gradle plugins, so if anything is wrong feel free to correct it. I also originally thought of making an issue, but since i already fixed the issues myself i decided to just open a pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New multiversion build options: customizable archive name, classifier, version, destination, and configurable input jars.
  * Enhanced resource handling with JSON-based mixin/resource adjustments during relocation.
* **Refactor**
  * Merge task now sources settings from the multiversion configuration for cleaner setup.
  * Relocation flow reworked to support multi‑pass processing and explicit resource handling.
* **Bug Fixes**
  * Fixed input-jar handling and archive versioning behavior in the merge process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->