### PR TITLE
Custom file handler (Also workaround for issue with mixin paths in mixin configs)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,12 +108,29 @@ pluginBundle {
 }
 
 publishing {
+	publications {
+		pluginMaven(MavenPublication) {
+			artifactId = "forgix"
+		}
+	}
+
     repositories {
         maven {
             name = 'localPluginRepository'
             url = '../local-plugin-repository'
         }
     }
+
+	repositories {
+		maven {
+			name = "Github"
+			url = "https://maven.pkg.github.com/ThePandaOliver/Forgix"
+			credentials {
+				username = System.getenv("GITHUB_USER")
+				password = System.getenv("GITHUB_API_TOKEN")
+			}
+		}
+	}
 }
 
 tasks.withType(GenerateModuleMetadata).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -108,29 +108,12 @@ pluginBundle {
 }
 
 publishing {
-	publications {
-		pluginMaven(MavenPublication) {
-			artifactId = "forgix"
-		}
-	}
-
     repositories {
         maven {
             name = 'localPluginRepository'
             url = '../local-plugin-repository'
         }
     }
-
-	repositories {
-		maven {
-			name = "Github"
-			url = "https://maven.pkg.github.com/ThePandaOliver/Forgix"
-			credentials {
-				username = System.getenv("GITHUB_USER")
-				password = System.getenv("GITHUB_API_TOKEN")
-			}
-		}
-	}
 }
 
 tasks.withType(GenerateModuleMetadata).configureEach {

--- a/src/main/java/io/github/pacifistmc/forgix/Forgix.java
+++ b/src/main/java/io/github/pacifistmc/forgix/Forgix.java
@@ -3,6 +3,7 @@ package io.github.pacifistmc.forgix;
 import io.github.pacifistmc.forgix.core.Multiversion;
 import io.github.pacifistmc.forgix.core.RelocationConfig;
 import io.github.pacifistmc.forgix.core.Relocator;
+import io.github.pacifistmc.forgix.plugin.configurations.ForgixConfiguration;
 import io.github.pacifistmc.forgix.utils.JAR;
 
 import java.io.File;
@@ -13,11 +14,13 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 public class Forgix {
-    public static final String VERSION = "2.0.0-fork.9";
+    public static final String VERSION = "2.0.0-fork.11";
     private static final String MANIFEST_VERSION_KEY = "Forgix-Version";
     private static final String MANIFEST_MAPPINGS_KEY = "Forgix-Mappings";
 
-    public static void mergeLoaders(Map<File, String> jarsAndLoadersMap, File outputFile, boolean silence = false) {
+    public static void mergeLoaders(Map<File, String> jarsAndLoadersMap, File outputFile,
+                                    Map<String, ForgixConfiguration.CustomFileHandler> customFileHandlers = new HashMap(),
+                                    boolean silence = false) {
         if (!silence) {
             """
             Thank you for using Forgix!
@@ -27,7 +30,7 @@ public class Forgix {
 
         List<RelocationConfig> configs = new ArrayList<>();
         jarsAndLoadersMap.forEach((jar, loader) -> configs.add(new RelocationConfig(new JarFile(jar), loader)));
-        Relocator.relocate(configs);
+        Relocator.relocate(configs, customFileHandlers);
 
         Map<File, String> tinyFiles = configs.stream()
                 .map(RelocationConfig::getTinyFile)

--- a/src/main/java/io/github/pacifistmc/forgix/Forgix.java
+++ b/src/main/java/io/github/pacifistmc/forgix/Forgix.java
@@ -13,7 +13,7 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 public class Forgix {
-    public static final String VERSION = "2.0.0-SNAPSHOT.5.1-FORK.3";
+    public static final String VERSION = "2.0.0-SNAPSHOT.5.1-FORK.4";
     private static final String MANIFEST_VERSION_KEY = "Forgix-Version";
     private static final String MANIFEST_MAPPINGS_KEY = "Forgix-Mappings";
 

--- a/src/main/java/io/github/pacifistmc/forgix/Forgix.java
+++ b/src/main/java/io/github/pacifistmc/forgix/Forgix.java
@@ -3,6 +3,7 @@ package io.github.pacifistmc.forgix;
 import io.github.pacifistmc.forgix.core.Multiversion;
 import io.github.pacifistmc.forgix.core.RelocationConfig;
 import io.github.pacifistmc.forgix.core.Relocator;
+import io.github.pacifistmc.forgix.core.filehandlers.CustomFileHandler;
 import io.github.pacifistmc.forgix.plugin.configurations.ForgixConfiguration;
 import io.github.pacifistmc.forgix.utils.JAR;
 
@@ -14,12 +15,12 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 public class Forgix {
-    public static final String VERSION = "2.0.0-fork.11";
+    public static final String VERSION = "2.0.0-SNAPSHOT.5.1";
     private static final String MANIFEST_VERSION_KEY = "Forgix-Version";
     private static final String MANIFEST_MAPPINGS_KEY = "Forgix-Mappings";
 
     public static void mergeLoaders(Map<File, String> jarsAndLoadersMap, File outputFile,
-                                    Map<String, ForgixConfiguration.CustomFileHandler> customFileHandlers = new HashMap(),
+                                    Map<String, CustomFileHandler> customFileHandlers = new HashMap(),
                                     boolean silence = false) {
         if (!silence) {
             """

--- a/src/main/java/io/github/pacifistmc/forgix/Forgix.java
+++ b/src/main/java/io/github/pacifistmc/forgix/Forgix.java
@@ -13,7 +13,7 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 public class Forgix {
-    public static final String VERSION = "2.0.0-SNAPSHOT.5.1-FORK.4";
+    public static final String VERSION = "2.0.0-fork.9";
     private static final String MANIFEST_VERSION_KEY = "Forgix-Version";
     private static final String MANIFEST_MAPPINGS_KEY = "Forgix-Mappings";
 

--- a/src/main/java/io/github/pacifistmc/forgix/Forgix.java
+++ b/src/main/java/io/github/pacifistmc/forgix/Forgix.java
@@ -13,7 +13,7 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 public class Forgix {
-    public static final String VERSION = "2.0.0-SNAPSHOT.5.1";
+    public static final String VERSION = "2.0.0-SNAPSHOT.5.1-FORK.3";
     private static final String MANIFEST_VERSION_KEY = "Forgix-Version";
     private static final String MANIFEST_MAPPINGS_KEY = "Forgix-Mappings";
 

--- a/src/main/java/io/github/pacifistmc/forgix/core/Multiversion.java
+++ b/src/main/java/io/github/pacifistmc/forgix/core/Multiversion.java
@@ -48,7 +48,7 @@ public class Multiversion {
 
             var relocationConfig = new RelocationConfig(jarFile, uuid);
             relocationConfig.setMappings(renameMap);
-            Relocator.relocate(List.of(relocationConfig));
+            Relocator.relocate(List.of(relocationConfig), Map.of());
         }
 
         JAR.removeFiles(multiversionJar, List.of(

--- a/src/main/java/io/github/pacifistmc/forgix/core/RelocationConfig.java
+++ b/src/main/java/io/github/pacifistmc/forgix/core/RelocationConfig.java
@@ -1,5 +1,7 @@
 package io.github.pacifistmc.forgix.core;
 
+import io.github.pacifistmc.forgix.plugin.configurations.ForgixConfiguration;
+
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/io/github/pacifistmc/forgix/core/Relocator.java
+++ b/src/main/java/io/github/pacifistmc/forgix/core/Relocator.java
@@ -1,5 +1,6 @@
 package io.github.pacifistmc.forgix.core;
 
+import io.github.pacifistmc.forgix.core.filehandlers.CustomFileHandler;
 import io.github.pacifistmc.forgix.plugin.configurations.ForgixConfiguration;
 import io.github.pacifistmc.forgix.utils.JAR;
 import io.github.pacifistmc.forgix.utils.TinyClassWriter;
@@ -32,7 +33,7 @@ public class Relocator {
      * @param relocationConfigs  The relocationConfigs to process
      * @param customFileHandlers
      */
-	public static void relocate(List<RelocationConfig> relocationConfigs, Map<String, ForgixConfiguration.CustomFileHandler> customFileHandlers) {
+	public static void relocate(List<RelocationConfig> relocationConfigs, Map<String, CustomFileHandler> customFileHandlers) {
 		relocateClasses(relocationConfigs);
 		relocateResources(relocationConfigs, customFileHandlers);
 	}
@@ -121,7 +122,7 @@ public class Relocator {
 	 *
 	 * @param relocationConfigs The relocationConfigs to process
 	 */
-	public static void relocateResources(List<RelocationConfig> relocationConfigs, Map<String, ForgixConfiguration.CustomFileHandler> customFileHandlers, boolean anotherPass=false) {
+	public static void relocateResources(List<RelocationConfig> relocationConfigs, Map<String, CustomFileHandler> customFileHandlers, boolean anotherPass=false) {
 		// Generate mappings if they don't exist or this is another pass
 		if (anotherPass || relocationConfigs.getFirst().tinyFile == null) generateMappings(relocationConfigs, !anotherPass);
 
@@ -163,7 +164,7 @@ public class Relocator {
 			resources.parallelStream().forEach(entry -> {
 				String content = JAR.getResource(jarFile, entry);
 				// Get the custom handler for this file if the name fits a pattern
-				ForgixConfiguration.CustomFileHandler handler = customFileHandlers.entrySet()
+				CustomFileHandler handler = customFileHandlers.entrySet()
 						.stream()
 						.filter(entry1 -> {
 							var matcher = FileSystems.getDefault().getPathMatcher("glob:${entry1.key}");

--- a/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/CustomFileHandler.java
+++ b/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/CustomFileHandler.java
@@ -1,0 +1,8 @@
+package io.github.pacifistmc.forgix.core.filehandlers;
+
+import java.util.Map;
+
+@FunctionalInterface
+public interface CustomFileHandler {
+    String handle(String fileName, String fileContent, Map<String, String> replacementPaths);
+}

--- a/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/MixinFileHandler.java
+++ b/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/MixinFileHandler.java
@@ -25,18 +25,27 @@ public class MixinFileHandler implements CustomFileHandler {
         }
 
         JsonArray clientMixinPaths = mixinJson.getAsJsonArray("client");
-        JsonArray newClientMixinPaths = new JsonArray();
-        for (JsonElement mixinPath : clientMixinPaths) {
-            String fullPath = packagePath + "." + mixinPath.getAsString();
-            if (replacementPaths.containsKey(fullPath))
-                newClientMixinPaths.add(replacementPaths.get(fullPath).substring(packagePath.length() + 1));
-            else
-                newClientMixinPaths.add(mixinPath);
+        if (clientMixinPaths != null) {
+            JsonArray newClientMixinPaths = new JsonArray();
+            for (JsonElement mixinPath : clientMixinPaths) {
+                String fullPath = packagePath + "." + mixinPath.getAsString();
+                if (replacementPaths.containsKey(fullPath))
+                    newClientMixinPaths.add(replacementPaths.get(fullPath).substring(packagePath.length() + 1));
+                else
+                    newClientMixinPaths.add(mixinPath);
+            }
+            mixinJson.add("client", newClientMixinPaths);
         }
-        mixinJson.add("client", newClientMixinPaths);
 
         JsonPrimitive mixinPlugin = mixinJson.getAsJsonPrimitive("plugin");
+        if (mixinPlugin != null) {
+            mixinJson.addProperty("plugin", replacementPaths.get(mixinPlugin.getAsString()));
+        }
+
         JsonPrimitive mixinRef = mixinJson.getAsJsonPrimitive("refmap");
+        if (mixinRef != null) {
+            mixinJson.addProperty("refmap", replacementPaths.get(mixinRef.getAsString()));
+        }
 
         return gson.toJson(mixinJson);
     }

--- a/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/MixinFileHandler.java
+++ b/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/MixinFileHandler.java
@@ -39,12 +39,18 @@ public class MixinFileHandler implements CustomFileHandler {
 
         JsonPrimitive mixinPlugin = mixinJson.getAsJsonPrimitive("plugin");
         if (mixinPlugin != null) {
-            mixinJson.addProperty("plugin", replacementPaths.get(mixinPlugin.getAsString()));
+            if (replacementPaths.containsKey(mixinPlugin.getAsString()))
+                mixinJson.addProperty("plugin", replacementPaths.get(mixinPlugin.getAsString()));
+            else
+                mixinJson.addProperty("plugin", mixinPlugin.getAsString());
         }
 
         JsonPrimitive mixinRef = mixinJson.getAsJsonPrimitive("refmap");
         if (mixinRef != null) {
-            mixinJson.addProperty("refmap", replacementPaths.get(mixinRef.getAsString()));
+            if (replacementPaths.containsKey(mixinRef.getAsString()))
+                mixinJson.addProperty("refmap", replacementPaths.get(mixinRef.getAsString()));
+            else
+                mixinJson.addProperty("refmap", mixinRef.getAsString());
         }
 
         return gson.toJson(mixinJson);

--- a/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/MixinFileHandler.java
+++ b/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/MixinFileHandler.java
@@ -1,11 +1,10 @@
 package io.github.pacifistmc.forgix.core.filehandlers;
 
 import com.google.gson.*;
-import io.github.pacifistmc.forgix.plugin.configurations.ForgixConfiguration;
 
 import java.util.Map;
 
-public class MixinFileHandler implements ForgixConfiguration.CustomFileHandler {
+public class MixinFileHandler implements CustomFileHandler {
     @Override
     public String handle(String fileName, String fileContent, Map<String, String> replacementPaths) {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();

--- a/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/MixinFileHandler.java
+++ b/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/MixinFileHandler.java
@@ -1,0 +1,42 @@
+package io.github.pacifistmc.forgix.core.filehandlers;
+
+import com.google.gson.*;
+import io.github.pacifistmc.forgix.plugin.configurations.ForgixConfiguration;
+
+import java.util.Map;
+
+public class MixinFileHandler implements ForgixConfiguration.CustomFileHandler {
+    @Override
+    public String handle(String fileName, String fileContent, Map<String, String> replacementPaths) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        JsonObject mixinJson = gson.fromJson(fileContent, JsonObject.class);
+        String packagePath = mixinJson.get("package").getAsString();
+
+        JsonArray commonMixinPaths = mixinJson.getAsJsonArray("mixins");
+        JsonArray newCommonMixinPaths = new JsonArray();
+        for (JsonElement mixinPath : commonMixinPaths) {
+            String fullPath = packagePath + "." + mixinPath.getAsString();
+            if (replacementPaths.containsKey(fullPath))
+                newCommonMixinPaths.add(replacementPaths.get(fullPath).substring(packagePath.length() + 1));
+            else
+                newCommonMixinPaths.add(mixinPath);
+        }
+        mixinJson.add("mixins", newCommonMixinPaths);
+
+        JsonArray clientMixinPaths = mixinJson.getAsJsonArray("client");
+        JsonArray newClientMixinPaths = new JsonArray();
+        for (JsonElement mixinPath : clientMixinPaths) {
+            String fullPath = packagePath + "." + mixinPath.getAsString();
+            if (replacementPaths.containsKey(fullPath))
+                newClientMixinPaths.add(replacementPaths.get(fullPath).substring(packagePath.length() + 1));
+            else
+                newClientMixinPaths.add(mixinPath);
+        }
+        mixinJson.add("client", newClientMixinPaths);
+
+        JsonPrimitive mixinPlugin = mixinJson.getAsJsonPrimitive("plugin");
+        JsonPrimitive mixinRef = mixinJson.getAsJsonPrimitive("refmap");
+
+        return gson.toJson(mixinJson);
+    }
+}

--- a/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/MixinFileHandler.java
+++ b/src/main/java/io/github/pacifistmc/forgix/core/filehandlers/MixinFileHandler.java
@@ -12,15 +12,17 @@ public class MixinFileHandler implements CustomFileHandler {
         String packagePath = mixinJson.get("package").getAsString();
 
         JsonArray commonMixinPaths = mixinJson.getAsJsonArray("mixins");
-        JsonArray newCommonMixinPaths = new JsonArray();
-        for (JsonElement mixinPath : commonMixinPaths) {
-            String fullPath = packagePath + "." + mixinPath.getAsString();
-            if (replacementPaths.containsKey(fullPath))
-                newCommonMixinPaths.add(replacementPaths.get(fullPath).substring(packagePath.length() + 1));
-            else
-                newCommonMixinPaths.add(mixinPath);
+        if (commonMixinPaths != null) {
+            JsonArray newCommonMixinPaths = new JsonArray();
+            for (JsonElement mixinPath : commonMixinPaths) {
+                String fullPath = packagePath + "." + mixinPath.getAsString();
+                if (replacementPaths.containsKey(fullPath))
+                    newCommonMixinPaths.add(replacementPaths.get(fullPath).substring(packagePath.length() + 1));
+                else
+                    newCommonMixinPaths.add(mixinPath);
+            }
+            mixinJson.add("mixins", newCommonMixinPaths);
         }
-        mixinJson.add("mixins", newCommonMixinPaths);
 
         JsonArray clientMixinPaths = mixinJson.getAsJsonArray("client");
         JsonArray newClientMixinPaths = new JsonArray();

--- a/src/main/java/io/github/pacifistmc/forgix/plugin/configurations/ForgixConfiguration.java
+++ b/src/main/java/io/github/pacifistmc/forgix/plugin/configurations/ForgixConfiguration.java
@@ -1,5 +1,7 @@
 package io.github.pacifistmc.forgix.plugin.configurations;
 
+import com.google.gson.*;
+import io.github.pacifistmc.forgix.core.filehandlers.MixinFileHandler;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
@@ -22,6 +24,7 @@ public class ForgixConfiguration {
     private final Property<Directory> destinationDirectory;
     private final Map<String, MergeLoaderConfiguration> mergeConfigurations = new HashMap<>();
     public MultiversionConfiguration multiversionConfiguration;
+    private final Map<String, CustomFileHandler> customFileHandlers = new HashMap<>();
 
     private final Map<String, Consumer<ForgixConfiguration>> LOADER_DEFAULT_METHOD_MAP = new HashMap<>();
     private final Project rootProject;
@@ -325,6 +328,25 @@ public class ForgixConfiguration {
         public Property<FileCollection> getInputJars() {
             return inputJars;
         }
+    }
+
+    // Custom file handling stuff
+
+    public void mixinHandler(String mixinNamePattern) {
+        fileHandler(mixinNamePattern, new MixinFileHandler());
+    }
+
+    public void fileHandler(String fileNamePattern, CustomFileHandler handler) {
+        customFileHandlers.put(fileNamePattern, handler);
+    }
+
+    public Map<String, CustomFileHandler> getCustomFileHandlers() {
+        return customFileHandlers;
+    }
+
+    @FunctionalInterface
+    public interface CustomFileHandler {
+        String handle(String fileName, String fileContent, Map<String, String> replacementPaths);
     }
 
     // Internal Gradle stuff

--- a/src/main/java/io/github/pacifistmc/forgix/plugin/configurations/ForgixConfiguration.java
+++ b/src/main/java/io/github/pacifistmc/forgix/plugin/configurations/ForgixConfiguration.java
@@ -1,6 +1,7 @@
 package io.github.pacifistmc.forgix.plugin.configurations;
 
 import com.google.gson.*;
+import io.github.pacifistmc.forgix.core.filehandlers.CustomFileHandler;
 import io.github.pacifistmc.forgix.core.filehandlers.MixinFileHandler;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -342,11 +343,6 @@ public class ForgixConfiguration {
 
     public Map<String, CustomFileHandler> getCustomFileHandlers() {
         return customFileHandlers;
-    }
-
-    @FunctionalInterface
-    public interface CustomFileHandler {
-        String handle(String fileName, String fileContent, Map<String, String> replacementPaths);
     }
 
     // Internal Gradle stuff

--- a/src/main/java/io/github/pacifistmc/forgix/plugin/configurations/ForgixConfiguration.java
+++ b/src/main/java/io/github/pacifistmc/forgix/plugin/configurations/ForgixConfiguration.java
@@ -333,8 +333,8 @@ public class ForgixConfiguration {
 
     // Custom file handling stuff
 
-    public void mixinHandler(String mixinNamePattern) {
-        fileHandler(mixinNamePattern, new MixinFileHandler());
+    public void mixin(String mixinPathPattern) {
+        fileHandler(mixinPathPattern, new MixinFileHandler());
     }
 
     public void fileHandler(String fileNamePattern, CustomFileHandler handler) {

--- a/src/main/java/io/github/pacifistmc/forgix/plugin/tasks/MergeJarsTask.java
+++ b/src/main/java/io/github/pacifistmc/forgix/plugin/tasks/MergeJarsTask.java
@@ -74,7 +74,7 @@ public abstract class MergeJarsTask extends Jar {
         }
 
         // Perform the merge operation
-        Forgix.mergeLoaders(jarMap, outputFile, silence.get());
+        Forgix.mergeLoaders(jarMap, outputFile, settings.customFileHandlers, silence.get());
     }
 
     @Override


### PR DESCRIPTION
While thinking of a fix for the mixin issue where the mixin class paths in the mixin configs aren't being remapped to their new name, i thought of just implementing a custom file handling API for files that need special handling as a workaround.

It can be used like this (The example is written in Kotlin DSL)
```kotlin
forgix {
	// Mixin handler preset
	mixinHandler("**.mixins.json")

	// Custom file handler
	fileHandler("**/something.*.xml") { fileName, fileContent, replacementPaths ->
		return // The modified file content
	}
}
```

Im not sure how to implement this with CLI, but it will probably only be capable of using preset handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extensible custom file handler support to transform file contents during relocation, with APIs updated to accept handler mappings while preserving default behavior when none are provided.
  * Built-in mixin handler to automatically update mixin configuration paths.
  * Build/task flow updated to forward configured handlers through the relocation process.

* **Tests**
  * Added tests validating custom file handling and mixin updates during relocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->